### PR TITLE
Fix Xcode finder URL handling

### DIFF
--- a/Sources/Actions/Xcode.swift
+++ b/Sources/Actions/Xcode.swift
@@ -35,13 +35,13 @@ extension Xcode {
                 if shortVersion.split(separator: ".").count == 2 {
                     shortVersion += ".0"
                 }
-                if let version = Version(shortVersion),
-                   let path = URL(string: fullPath),
-                   let url = URL(string: "file://\(path.absoluteString)/"),
-                   url.startAccessingSecurityScopedResource() {
-                    xcodeApps.append(
-                        .init(appName: filePath, shortVersion: version, bundleVersion: bundleVersion, url: url)
-                    )
+                if let version = Version(shortVersion) {
+                    let url = URL(fileURLWithPath: fullPath)
+                    if url.startAccessingSecurityScopedResource() {
+                        xcodeApps.append(
+                            .init(appName: filePath, shortVersion: version, bundleVersion: bundleVersion, url: url)
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix `Xcode.find()` to create URLs from file paths correctly

## Testing
- `swift build` *(fails: no module 'AppKit' on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_684f9c0ce81c8330909567675c5fb836