### PR TITLE
Add initial tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,11 @@ let package = Package(
         "ANSITerminal"
       ],
       path: "Sources"
+    ),
+    .testTarget(
+      name: "BluffXcodesTests",
+      dependencies: ["bluffxcodes"],
+      path: "Tests"
     )
   ]
 )

--- a/Sources/Actions/Xcode.swift
+++ b/Sources/Actions/Xcode.swift
@@ -37,11 +37,16 @@ extension Xcode {
                 }
                 if let version = Version(shortVersion),
                    let path = URL(string: fullPath),
-                   let url = URL(string: "file://\(path.absoluteString)/"),
-                   url.startAccessingSecurityScopedResource() {
-                    xcodeApps.append(
-                        .init(appName: filePath, shortVersion: version, bundleVersion: bundleVersion, url: url)
-                    )
+                   let url = URL(string: "file://\(path.absoluteString)/") {
+                    var allowed = true
+#if os(macOS)
+                    allowed = url.startAccessingSecurityScopedResource()
+#endif
+                    if allowed {
+                        xcodeApps.append(
+                            .init(appName: filePath, shortVersion: version, bundleVersion: bundleVersion, url: url)
+                        )
+                    }
                 }
             }
         }

--- a/Sources/Actions/XcodeBluff.swift
+++ b/Sources/Actions/XcodeBluff.swift
@@ -1,6 +1,9 @@
 import Foundation
+#if canImport(AppKit)
 import AppKit
+#endif
 
+#if canImport(AppKit)
 struct XcodeBluff {
 
     static func bluff(selectedXcode: Xcode, latestXcode: Xcode) throws {
@@ -33,6 +36,7 @@ struct XcodeBluff {
         try data.write(to: infoPlistUrl)
     }
 }
+#endif
 
 extension Dictionary {
 

--- a/Sources/Main.swift
+++ b/Sources/Main.swift
@@ -11,7 +11,9 @@ struct Bluffxcodes: ParsableCommand {
     mutating func run() {
         do {
             let xcodes = try XcodeSelection.perform()
+#if canImport(AppKit)
             try XcodeBluff.bluff(selectedXcode: xcodes.selected, latestXcode: xcodes.latest)
+#endif
         } catch {
             write(error.localizedDescription, style: .error)
         }

--- a/Tests/BluffXcodesTests/BluffXcodesTests.swift
+++ b/Tests/BluffXcodesTests/BluffXcodesTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import bluffxcodes
+import Version
+
+final class BluffXcodesTests: XCTestCase {
+    func testStepReturnsValue() throws {
+        let value = try step(title: "Test") { return 42 }
+        XCTAssertEqual(value, 42)
+    }
+
+    func testStepThrows() {
+        enum SampleError: Swift.Error { case fail }
+        XCTAssertThrowsError(try step(title: "Fail") { throw SampleError.fail })
+    }
+
+    func testDictionaryContents() throws {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: "test.plist")
+        let original: [String: Any] = [
+            "A": 1,
+            "B": "two"
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: original, format: .xml, options: 0)
+        try data.write(to: url)
+        let result = try Dictionary<String, AnyObject>.contentsOf(path: url)
+        XCTAssertEqual(result?["A"] as? Int, 1)
+        XCTAssertEqual(result?["B"] as? String, "two")
+    }
+
+    func testXcodeFind() throws {
+        let apps = URL(fileURLWithPath: Constants.applicationsPath)
+        try? FileManager.default.removeItem(at: apps)
+        try FileManager.default.createDirectory(at: apps, withIntermediateDirectories: true)
+
+        func createApp(name: String, short: String, build: String) throws {
+            let contents = apps.appending(path: name).appending(path: "Contents")
+            try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+            let infoURL = contents.appending(path: "Info.plist")
+            let dict: [String: Any] = [
+                "CFBundleIdentifier": Constants.xcodeBundleID,
+                "CFBundleShortVersionString": short,
+                "CFBundleVersion": build
+            ]
+            let data = try PropertyListSerialization.data(fromPropertyList: dict, format: .xml, options: 0)
+            try data.write(to: infoURL)
+        }
+
+        try createApp(name: "Xcode1.app", short: "1.0", build: "1")
+        try createApp(name: "Xcode2.app", short: "2.0", build: "2")
+
+        let found = Xcode.find().sorted { $0.appName < $1.appName }
+        XCTAssertEqual(found.count, 2)
+        XCTAssertEqual(found[0].appName, "Xcode1.app")
+        XCTAssertEqual(found[1].shortVersion, Version("2.0.0")!)
+    }
+}


### PR DESCRIPTION
## Summary
- make Linux-friendly by conditionalizing macOS code
- add SPM test target
- add tests for `step`, `Dictionary.contentsOf`, and `Xcode.find`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684f9d80a6508330a8e61a1faf4799f0