### PR TITLE
Ensure security scoped access for both URLs

### DIFF
--- a/Sources/Actions/XcodeBluff.swift
+++ b/Sources/Actions/XcodeBluff.swift
@@ -5,7 +5,10 @@ struct XcodeBluff {
 
     static func bluff(selectedXcode: Xcode, latestXcode: Xcode) throws {
         try step(title: "Bluffing Xcode applications...") {
-            guard selectedXcode.url.startAccessingSecurityScopedResource() else { return }
+            guard selectedXcode.url.startAccessingSecurityScopedResource(),
+                  latestXcode.url.startAccessingSecurityScopedResource() else {
+                throw Error.custom("Could not access Xcode applications. Ensure the tool has Full Disk Access.")
+            }
 
             try update(bundleVersion: latestXcode.bundleVersion, to: selectedXcode.url)
 


### PR DESCRIPTION
## Summary
- start security-scoped resource access for the latest Xcode
- fail with an error if either URL cannot be accessed

## Testing
- `swift build` *(fails: no such module 'AppKit')*

------
https://chatgpt.com/codex/tasks/task_e_684fb0b22648833087df67331564e260