### PR TITLE
Fix Titleable protocol name

### DIFF
--- a/Sources/Actions/Xcode.swift
+++ b/Sources/Actions/Xcode.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Version
 
-struct Xcode: Titlable {
+struct Xcode: Titleable {
 
     let appName: String
     let shortVersion: Version

--- a/Sources/Helpers/Picker.swift
+++ b/Sources/Helpers/Picker.swift
@@ -1,6 +1,6 @@
 import ANSITerminal
 
-protocol Titlable {
+protocol Titleable {
 
     var title: String { get }
 }
@@ -37,7 +37,7 @@ fileprivate class OptionState {
     }
 }
 
-func picker<T: Titlable>(title: String, options: [T]) -> T {
+func picker<T: Titleable>(title: String, options: [T]) -> T {
     cursorOff()
     write("◆".foreColor(81).bold)
     moveRight()


### PR DESCRIPTION
## Summary
- rename `Titlable` protocol to `Titleable`
- update protocol conformance in `Xcode`
- adapt generic constraint for picker

## Testing
- `swift build` *(fails: no such module 'AppKit')*
- `swift test` *(fails: no such module 'AppKit')*

------
https://chatgpt.com/codex/tasks/task_e_684fb0ac85d0833096237101280774de