### PR TITLE
Load all Xcodes automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ bluffxcodes
 
 The tool will automatically:
 
-1. Detect your installed Xcode versions.
-2. Update the bundle version to enable compatibility for the selected Xcode.
-3. Display the results of the operation and open the selected Xcode version.
+1. Detect your installed Xcode versions in the background.
+2. Update the bundle version for each older Xcode and attempt to open it.
+3. Display a list of Xcode versions that opened successfully.
 
 From this point on, you can use the selected Xcode as normal (e.g., open it from the dock, Spotlight, etc.).
 

--- a/Sources/Actions/XcodeBluff.swift
+++ b/Sources/Actions/XcodeBluff.swift
@@ -3,7 +3,7 @@ import AppKit
 
 struct XcodeBluff {
 
-    static func bluff(selectedXcode: Xcode, latestXcode: Xcode) throws {
+    private static func bluff(selectedXcode: Xcode, latestXcode: Xcode) throws {
         try step(title: "Bluffing Xcode applications...") {
             guard selectedXcode.url.startAccessingSecurityScopedResource(),
                   latestXcode.url.startAccessingSecurityScopedResource() else {
@@ -23,6 +23,24 @@ struct XcodeBluff {
 
             selectedXcode.url.stopAccessingSecurityScopedResource()
             latestXcode.url.stopAccessingSecurityScopedResource()
+        }
+    }
+
+    static func bluffAll(xcodes: [Xcode]) throws -> [Xcode] {
+        return try step(title: "Bluffing Xcode applications...") {
+            guard let latest = xcodes.last else { return [] }
+            var opened: [Xcode] = []
+            for xcode in xcodes.dropLast() {
+                do {
+                    try bluff(selectedXcode: xcode, latestXcode: latest)
+                    opened.append(xcode)
+                } catch {
+                    write("Failed to open \(xcode.shortVersion)", style: .warning)
+                }
+            }
+            let versions = opened.map { $0.shortVersion.description }.joined(separator: ", ")
+            write("Successfully opened: \(versions)", style: .success)
+            return opened
         }
     }
 

--- a/Sources/Actions/XcodeSelection.swift
+++ b/Sources/Actions/XcodeSelection.swift
@@ -1,18 +1,20 @@
 struct XcodeSelection {
 
-    static func perform() throws -> (selected: Xcode, latest: Xcode) {
-        return try step(title: "Loading Xcode applications...") {
-            let xcodes = Xcode.find().sorted(by: { $0.shortVersion < $1.shortVersion })
-            if xcodes.isEmpty || xcodes.count < 1 {
+    static func loadAll() throws -> [Xcode] {
+        return try step(title: "Loading Xcode applications in background...") {
+            var xcodes: [Xcode] = []
+            let group = DispatchGroup()
+            group.enter()
+            DispatchQueue.global().async {
+                xcodes = Xcode.find().sorted(by: { $0.shortVersion < $1.shortVersion })
+                group.leave()
+            }
+            group.wait()
+            if xcodes.count < 2 {
                 write("Required at least 2 Xcodes into your system", style: .error)
                 throw Error.notFound
             }
-            let selected = picker(
-                title: "Select the old Xcode you want to use!",
-                options: xcodes
-            )
-            write("Selected Xcode: \(selected.shortVersion)", style: .success)
-            return (selected, xcodes.last!)
+            return xcodes
         }
     }
 }

--- a/Sources/Main.swift
+++ b/Sources/Main.swift
@@ -10,8 +10,8 @@ struct Bluffxcodes: ParsableCommand {
 
     mutating func run() {
         do {
-            let xcodes = try XcodeSelection.perform()
-            try XcodeBluff.bluff(selectedXcode: xcodes.selected, latestXcode: xcodes.latest)
+            let xcodes = try XcodeSelection.loadAll()
+            _ = try XcodeBluff.bluffAll(xcodes: xcodes)
         } catch {
             write(error.localizedDescription, style: .error)
         }


### PR DESCRIPTION
## Summary
- load available Xcodes in the background
- open all older Xcode versions automatically
- show which Xcodes were opened
- update documentation

## Testing
- `swift test -c release` *(fails: no such module 'AppKit')*

------
https://chatgpt.com/codex/tasks/task_e_684fd4e84a5c8330af33d284c3e3b044