### PR TITLE
✨ feat: add verbose logging

### DIFF
--- a/Sources/Helpers/Logger.swift
+++ b/Sources/Helpers/Logger.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+enum LogLevel: String {
+    case info
+    case success
+    case warning
+    case error
+}
+
+final class Logger {
+    static let shared = Logger()
+
+    var verbose: Bool = false
+    private let logURL: URL
+    private let formatter: ISO8601DateFormatter
+
+    private init() {
+        let logDir = FileManager.default.homeDirectoryForCurrentUser
+            .appending(path: "Library/Logs", directoryHint: .isDirectory)
+        try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
+        logURL = logDir.appending(path: "bluffxcodes.log")
+        formatter = ISO8601DateFormatter()
+    }
+
+    func log(_ message: String, level: LogLevel = .info) {
+        let entry: [String: String] = [
+            "timestamp": formatter.string(from: Date()),
+            "level": level.rawValue,
+            "message": message
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: entry),
+           let json = String(data: data, encoding: .utf8) {
+            if let handle = try? FileHandle(forWritingTo: logURL) {
+                handle.seekToEndOfFile()
+                if let lineData = (json + "\n").data(using: .utf8) {
+                    handle.write(lineData)
+                }
+                try? handle.close()
+            } else {
+                try? json.appending("\n").write(to: logURL, atomically: true, encoding: .utf8)
+            }
+        }
+        if verbose {
+            print("LOG[\(level.rawValue.uppercased())]: \(message)")
+        }
+    }
+}

--- a/Sources/Helpers/Terminal.swift
+++ b/Sources/Helpers/Terminal.swift
@@ -3,6 +3,7 @@ import ANSITerminal
 
 enum WriteStyle {
 
+    case info
     case success
     case error
     case warning
@@ -10,22 +11,30 @@ enum WriteStyle {
 
 func write(_ text: String, style: WriteStyle) {
     switch style {
+    case .info:
+        writeln(text)
+        Logger.shared.log(text, level: .info)
     case .success:
         writeln(text.green)
+        Logger.shared.log(text, level: .success)
     case .error:
         writeln(text.red)
+        Logger.shared.log(text, level: .error)
     case .warning:
         writeln(text.yellow)
+        Logger.shared.log(text, level: .warning)
     }
 }
 
 func step<T>(title: String, action: () throws -> T) throws -> T {
     writeln("→ \(title)".bold.lightGreen)
+    Logger.shared.log(title, level: .info)
 
     do {
         return try action()
     } catch {
         write(error.localizedDescription, style: .error)
+        Logger.shared.log(error.localizedDescription, level: .error)
         throw error
     }
 }

--- a/Sources/Main.swift
+++ b/Sources/Main.swift
@@ -8,7 +8,12 @@ struct Bluffxcodes: ParsableCommand {
         abstract: "Bluffing your Xcode versions with ease!"
     )
 
+    @Flag(name: .shortAndLong, help: "Enable verbose logging")
+    var verbose: Bool = false
+
     mutating func run() {
+        Logger.shared.verbose = verbose
+        Logger.shared.log("Running bluffxcodes", level: .info)
         do {
             let xcodes = try XcodeSelection.loadAll()
             _ = try XcodeBluff.bluffAll(xcodes: xcodes)


### PR DESCRIPTION
## Summary
- enable verbose mode using ArgumentParser flag
- record logs to `~/Library/Logs/bluffxcodes.log`
- capture step messages and output using a new `Logger` helper

## Testing
- `swift build` *(fails: no such module 'AppKit')*

------
https://chatgpt.com/codex/tasks/task_e_6852eeeb486083309826a8aabb91fdb4